### PR TITLE
Added Vanilla JavaScript version

### DIFF
--- a/README-vanilla.md
+++ b/README-vanilla.md
@@ -1,0 +1,34 @@
+# Form Filler - Automate Form Population with Vanilla JavaScript
+
+![GitHub](https://img.shields.io/github/license/mahsa-jannaty/form-filler)
+
+Automate the population of form fields with random data quickly using Vanilla JavaScript. This project is helpful for testing and development when you need to fill out forms for various scenarios.
+
+## Features
+
+-  Fill text inputs and textareas with random strings.
+-  Set number inputs to random numbers.
+-  Assign random file names to file input fields.
+-  Select random options in dropdown (select) elements.
+
+## Getting Started
+
+To start using this form filler, follow these steps:
+
+1. Add the `form-filler-vanilla.js` file next to the index.html file in your project (or anywhere else you want).
+
+2. Include this piece of code at the end of the HTML `head` tag:
+
+```html
+<script type="module">
+	import fillAllFormsWithFakeData from './form-filler-vanilla.js';
+	fillAllFormsWithFakeData();
+</script>
+```
+
+**Note:** Make sure the path of the file is defined corresponding to where you've saved the file in your project.
+
+### Prerequisites
+
+-  A server for serving and previewing the html file
+-  A modern web browser that suports [ES6 import/export syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)

--- a/README-vanilla.md
+++ b/README-vanilla.md
@@ -31,4 +31,4 @@ To start using this form filler, follow these steps:
 ### Prerequisites
 
 -  A server for serving and previewing the html file
--  A modern web browser that suports [ES6 import/export syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
+-  A modern web browser that suports [ES6 import/export syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and [DataTransfer API](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer)

--- a/form-filler-vanilla.js
+++ b/form-filler-vanilla.js
@@ -1,0 +1,51 @@
+export default function fillAllFormsWithFakeData() {
+	const forms = document.querySelectorAll('form');
+	forms.forEach(form => populateFormWithFakeData(form));
+}
+
+function populateFormWithFakeData(form) {
+	// Text inputs
+	const textInputs = form.querySelectorAll('input[type="text"]');
+	textInputs.forEach(input => (input.value = generateRandomString(10)));
+
+	// Textareas
+	const textareas = form.querySelectorAll('textarea');
+	textareas.forEach(textarea => (textarea.value = generateRandomString(10)));
+
+	// Number inputs
+	const numberInputs = form.querySelectorAll('input[type="number"]');
+	numberInputs.forEach(input => (input.value = generateRandomNumber()));
+
+	// File inputs
+	const dataTransfer = new DataTransfer();
+	const fileInputs = form.querySelectorAll('input[type="file"]');
+	fileInputs.forEach(input => {
+		dataTransfer.items.add(new File([], `fake-file-${generateRandomNumber()}.txt`));
+		input.files = dataTransfer.files;
+	});
+
+	// Combo boxes (HTML 'select' elements)
+	const comboBoxes = form.querySelectorAll('select');
+	comboBoxes.forEach(comboBox => {
+		const options = comboBox.querySelectorAll('option');
+		const randomOptionIndex = generateRandomNumber(0, options.length - 1);
+		options[randomOptionIndex].setAttribute('selected', '');
+	});
+}
+
+function generateRandomString(length = 8) {
+	const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	let result = '';
+
+	for (let i = 0; i < length; i++) {
+		const randomIndex = Math.floor(Math.random() * characters.length);
+		result += characters.charAt(randomIndex);
+	}
+
+	return result;
+}
+
+function generateRandomNumber(min = 1, max = 99999) {
+	const randomNumber = Math.floor(Math.random() * (max - min) + 1) + min;
+	return randomNumber;
+}


### PR DESCRIPTION
I tried to keep almost everything the same format as the jQuery version you created (even the new [README-vanilla.md file](https://github.com/ShayanTheNerd/Form-Filler/blob/main/README-vanilla.md)), but all as a single Vanilla JavaScript file. Obviously, it means that others can simply use this in their projects without having to install a dependency like jQuery just for the sake of simple tests.

It's also worth mentioning that this project can be expanded further more by adding new features, more customizable form-filling methods, a cleaner and more modular code, etc. However, I don't thinks it's really worth the time and effort because there are already many [free and useful form-filler libraries](https://github.com/topics/form-filler) out there in addition to this handy browser extension called [Fake Filler](https://chrome.google.com/webstore/detail/fake-filler/bnjjngeaknajbdcgpfkgnonkmififhfo).